### PR TITLE
Contribution workflow improvements

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,11 @@
+# vi: ft=dosini
+
+[general]
+contrib=contrib-title-conventional-commits
+ignore=body-is-missing
+
+[title-max-length]
+line-length=50
+
+[body-max-line-length]
+line-length=72

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+default_install_hook_types:
+  - pre-commit
+  - pre-merge-commit
+  - commit-msg
+default_stages:
+  - pre-commit
+  - pre-merge-commit
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-vcs-permalinks
+      - id: check-yaml
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: [--fix=no]
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+  - repo: https://github.com/JohnnyMorganz/StyLua
+    rev: v0.20.0
+    hooks:
+      - id: stylua
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.10.0
+    hooks:
+      - id: yamlfmt

--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ All contributions to Sort are greatly appreciated, whether it's a bug fix or a f
 
 Before making a pull request, please consider the following:
 
-- Follow the existing code style and formatting conventions .
-  - Install [stylua](https://github.com/johnnymorganz/stylua) to ensure proper formatting.
+- Initially, before you commit anything, install [pre-commit](https://pre-commit.com/) and its git hooks (`pre-commit install`). It ensures in particular that
+  - Lua code is properly formatting with [stylua](https://github.com/johnnymorganz/stylua) and
+  - commit messages are formatted according to the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+- Follow the existing code style.
 - Write clear and concise commit messages that describe the changes you've made.
 
 ## 🏁 Roadmap

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Sorting with the **Sort** plugin is made easy through the provided `:Sort` comma
 
   - Use `[!]` to reverse the sort order.
   - Use `[delimiter]` to manually set the delimiter instead of iterating over `config.delimiters` and sorting by the highest priority delimiter. Valid delimiters include:
-    - Any punctuation character (!, ?, &, ...), matching the `%p` lua pattern character class.
+    - Any punctuation character (!, ?, &, ...), matching the `%p` Lua pattern character class.
     - `s`: Space
     - `t`: Tab
   - Use `[b]` to sort based on the first binary number in the word.
@@ -145,7 +145,7 @@ Before making a pull request, please consider the following:
   - [x] `b` option to sort by binary (2).
   - [x] `n` option to sort by decimal (10).
   - [x] `o` option to sort by octal (8).
-  - [x] `x` option to sort by hexidecimal (16).
+  - [x] `x` option to sort by hexadecimal (16).
 - [ ] Improve test coverage to ensure the stability and reliability of the plugin.
 - [ ] Add support for natural sorting to provide more intuitive sorting of strings that include numeric values.
 - [ ] Add opt-in motion mappings to enable users to trigger Sort commands more efficiently using keybindings.

--- a/lua/sort/config.lua
+++ b/lua/sort/config.lua
@@ -21,5 +21,4 @@ M.setup = function(overrides)
   return user_config
 end
 
-
 return M

--- a/lua/sort/interface.lua
+++ b/lua/sort/interface.lua
@@ -27,13 +27,13 @@ end
 --- @return Selection
 M.get_visual_selection = function()
   local start_row, start_column = unpack(vim.api.nvim_buf_get_mark(0, '<'))
-  local stop_row, end_column = unpack(vim.api.nvim_buf_get_mark(0, '>'))
+  local stop_row, stop_column = unpack(vim.api.nvim_buf_get_mark(0, '>'))
   local is_selection_inversed = start_row > stop_row
-    or (start_row == stop_row and start_column >= end_column)
+    or (start_row == stop_row and start_column >= stop_column)
 
   local selection = {
     start = { row = start_row, column = start_column },
-    stop = { row = stop_row, column = end_column },
+    stop = { row = stop_row, column = stop_column },
   }
 
   local function swap_start_stop()

--- a/lua/sort/interface.lua
+++ b/lua/sort/interface.lua
@@ -26,8 +26,8 @@ end
 --- Get rows and columns of currect visual selection.
 --- @return Selection
 M.get_visual_selection = function()
-  local _, start_row, start_column, _ = unpack(vim.fn.getpos("'<"))
-  local _, stop_row, end_column, _ = unpack(vim.fn.getpos("'>"))
+  local start_row, start_column = unpack(vim.api.nvim_buf_get_mark(0, '<'))
+  local stop_row, end_column = unpack(vim.api.nvim_buf_get_mark(0, '>'))
   local is_selection_inversed = start_row > stop_row
     or (start_row == stop_row and start_column >= end_column)
 

--- a/lua/sort/interface.lua
+++ b/lua/sort/interface.lua
@@ -6,7 +6,7 @@ local maximum_line_length = 2147483647
 --- @param bang string
 --- @param arguments string
 M.execute_builtin_sort = function(bang, arguments)
-  vim.api.nvim_command('\'<,\'>sort' .. bang .. ' ' .. arguments)
+  vim.api.nvim_command("'<,'>sort" .. bang .. ' ' .. arguments)
 end
 
 --- Get text between two columns.
@@ -26,8 +26,8 @@ end
 --- Get rows and columns of currect visual selection.
 --- @return Selection
 M.get_visual_selection = function()
-  local _, start_row, start_column, _ = unpack(vim.fn.getpos('\'<'))
-  local _, stop_row, end_column, _ = unpack(vim.fn.getpos('\'>'))
+  local _, start_row, start_column, _ = unpack(vim.fn.getpos("'<"))
+  local _, stop_row, end_column, _ = unpack(vim.fn.getpos("'>"))
   local is_selection_inversed = start_row > stop_row
     or (start_row == stop_row and start_column >= end_column)
 

--- a/lua/sort/sort.lua
+++ b/lua/sort/sort.lua
@@ -72,18 +72,13 @@ M.delimiter_sort = function(text, options)
     local delimiterCount = #matches - 1
 
     if delimiterCount > 0 then
-      leading_whitespaces, trailing_whitespaces = M.get_whitespaces_around_word(
-        matches
-      )
+      leading_whitespaces, trailing_whitespaces =
+        M.get_whitespaces_around_word(matches)
       sorted_words = M.get_sorted_words(matches, options)
-      has_leading_delimiter = string.match(
-        text,
-        '^' .. top_translated_delimiter
-      )
-      has_trailing_delimiter = string.match(
-        text,
-        top_translated_delimiter .. '$'
-      )
+      has_leading_delimiter =
+        string.match(text, '^' .. top_translated_delimiter)
+      has_trailing_delimiter =
+        string.match(text, top_translated_delimiter .. '$')
       break
     end
   end


### PR DESCRIPTION
Hi, I'd like to merge various things which I consider improving the contribution workflow and the code base:

1. Integrate pre-commit (see updated README and the particular commit message).
2. Apply stylua formatting.
3. Replace `vim.fn.*` by Lua API calls.

In addition to the pre-commit checks already implemented by this pr, one may integrate checks to format and lint the README with [mdformat](https://github.com/executablebooks/mdformat) and [markdownlint](https://github.com/igorshubovych/markdownlint-cli). What do you think? I could easily add these checks if you agree.