### PR TITLE
fix: bundle of bug fixes for v2.4.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-04-17
+
+### Fixed
+
+- Delimiter sort now applies a uniform whitespace policy: the input's outer whitespace is preserved, interior gaps collapse to the dominant pattern, and spacing no longer depends on which item lands at each boundary.
+- Delimiter sort drops the structural empty segment at the leading boundary, so inputs like `,a,b` sort to `,a,b` instead of gaining duplicate delimiters.
+- Delimiter sort now treats magic Lua pattern characters (`(`, `)`, `.`, `%`, `+`, `*`, `?`, `^`, `$`, `-`) as literal delimiters.
+- Dot-repeat (`.`) of the sort operator uses the configuration active at the first invocation instead of reading live config at repeat time.
+- The sort operator warns and aborts instead of erroring when the buffer is non-modifiable.
+- Multi-line character motions are only promoted to line motions when both boundaries are line-shaped, preserving partial selections that span 3+ lines.
+- Whitespace trimming now handles Unicode whitespace (NBSP, ideographic space, line/paragraph separators) rather than only ASCII `%s`.
+- Numeric sort orders empty segments after numbers instead of coercing them to zero.
+- `:Sort` flag parsing now binds flag letters (`b`, `n`, `o`, `x`, `i`, `u`, `z`) first and warns on unknown characters; combining `s`/`t` with other flags no longer silently consumes them as delimiters.
+- `parse_number` requires the whole input to be a valid number for its base — `5xyz` no longer parses as `5`.
+- `is_pure_number` accepts leading-decimal numbers like `.5` and `-.5`.
+- Natural-sort parser treats a leading `-` before digits as a sign, so `-10, -5` sorts numerically in mixed lists.
+- `config.setup` validates override types (delimiters, mappings, whitespace, booleans) and warns on invalid values instead of silently accepting them.
+- `config.setup` no longer mutates the caller's overrides table.
+
 ## [2.4.0] - 2026-01-28
 
 ### Added
@@ -126,7 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keybinding examples with detailed explanations.
 - Documentation for numerical sorting options.
 
-[Unreleased]: https://github.com/sQVe/sort.nvim/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/sQVe/sort.nvim/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/sQVe/sort.nvim/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/sQVe/sort.nvim/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/sQVe/sort.nvim/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/sQVe/sort.nvim/compare/v2.2.0...v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dot-repeat (`.`) of the sort operator uses the configuration active at the first invocation instead of reading live config at repeat time.
 - The sort operator warns and aborts instead of erroring when the buffer is non-modifiable.
 - Multi-line character motions are only promoted to line motions when both boundaries are line-shaped, preserving partial selections that span 3+ lines.
-- Whitespace trimming now handles Unicode whitespace (NBSP, ideographic space, line/paragraph separators) rather than only ASCII `%s`.
+- Whitespace trimming now handles Unicode whitespace (NEL, NBSP, ideographic space, line/paragraph separators, em/en quads, etc.) rather than only ASCII `%s`.
+- Inner/around sortable-region text objects (`is`, `as`) snap deterministically to the nearest non-empty segment when the cursor is on a delimiter or past the last segment, and preserve the visual selection when invoked from visual mode.
 - Numeric sort orders empty segments after numbers instead of coercing them to zero.
 - `:Sort` flag parsing now binds flag letters (`b`, `n`, `o`, `x`, `i`, `u`, `z`) first and warns on unknown characters; combining `s`/`t` with other flags no longer silently consumes them as delimiters.
 - `parse_number` requires the whole input to be a valid number for its base — `5xyz` no longer parses as `5`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ When selecting within a single line, the plugin performs delimiter-based sorting
 - `x` - Sort by hexadecimal numbers
 - `z` - Natural sorting (handles numbers in strings properly)
 
+**Limitations:** Delimiter splitting is literal. Quoted strings (`"a,b",c`) and
+bracket-protected regions (`(a,b),c`) are not honored — the delimiter always
+splits, even inside a quoted value. If your data requires quote-aware
+splitting, preprocess it with a dedicated CSV tool before sorting.
+
 ### Motion-based sorting
 
 **Sort** provides Vim-style operators and text objects for efficient sorting:

--- a/lua/sort/config.lua
+++ b/lua/sort/config.lua
@@ -35,7 +35,7 @@ end
 --- @param overrides? Config
 --- @return Config user_config
 M.setup = function(overrides)
-  user_config = vim.tbl_deep_extend('force', defaults, overrides or {})
+  user_config = vim.tbl_deep_extend('force', user_config, overrides or {})
 
   return user_config
 end

--- a/lua/sort/config.lua
+++ b/lua/sort/config.lua
@@ -25,6 +25,72 @@ local defaults = {
 
 local user_config = defaults
 
+local function warn(key, expected, actual)
+  vim.notify(
+    string.format(
+      "sort.nvim: config '%s' expected %s, got %s — ignoring override",
+      key,
+      expected,
+      actual
+    ),
+    vim.log.levels.WARN
+  )
+end
+
+local function is_list_of_strings(value)
+  if type(value) ~= 'table' then
+    return false
+  end
+  for _, v in ipairs(value) do
+    if type(v) ~= 'string' then
+      return false
+    end
+  end
+  return true
+end
+
+--- Strip invalid keys from `overrides` in place, warning about each.
+--- Leaves the rest of `overrides` intact so valid keys still apply.
+local function validate(overrides)
+  if
+    overrides.delimiters ~= nil and not is_list_of_strings(overrides.delimiters)
+  then
+    warn('delimiters', 'list of strings', type(overrides.delimiters))
+    overrides.delimiters = nil
+  end
+
+  for _, key in ipairs({ 'keymap' }) do
+    if overrides[key] ~= nil and type(overrides[key]) ~= 'string' then
+      warn(key, 'string', type(overrides[key]))
+      overrides[key] = nil
+    end
+  end
+
+  for _, key in ipairs({ 'natural_sort', 'ignore_case', 'unique' }) do
+    if overrides[key] ~= nil and type(overrides[key]) ~= 'boolean' then
+      warn(key, 'boolean', type(overrides[key]))
+      overrides[key] = nil
+    end
+  end
+
+  if type(overrides.whitespace) == 'table' then
+    local threshold = overrides.whitespace.alignment_threshold
+    if threshold ~= nil then
+      if type(threshold) ~= 'number' or threshold < 0 then
+        warn(
+          'whitespace.alignment_threshold',
+          'non-negative number',
+          type(threshold) == 'number' and tostring(threshold) or type(threshold)
+        )
+        overrides.whitespace.alignment_threshold = nil
+      end
+    end
+  elseif overrides.whitespace ~= nil then
+    warn('whitespace', 'table', type(overrides.whitespace))
+    overrides.whitespace = nil
+  end
+end
+
 --- Get user config.
 --- @return Config user_config
 M.get_user_config = function()
@@ -35,7 +101,9 @@ end
 --- @param overrides? Config
 --- @return Config user_config
 M.setup = function(overrides)
-  user_config = vim.tbl_deep_extend('force', user_config, overrides or {})
+  overrides = overrides or {}
+  validate(overrides)
+  user_config = vim.tbl_deep_extend('force', user_config, overrides)
 
   return user_config
 end

--- a/lua/sort/config.lua
+++ b/lua/sort/config.lua
@@ -89,6 +89,46 @@ local function validate(overrides)
     warn('whitespace', 'table', type(overrides.whitespace))
     overrides.whitespace = nil
   end
+
+  if overrides.mappings ~= nil and overrides.mappings ~= false then
+    if type(overrides.mappings) ~= 'table' then
+      warn('mappings', 'table or false', type(overrides.mappings))
+      overrides.mappings = nil
+    else
+      local m = overrides.mappings
+      if
+        m.operator ~= nil
+        and m.operator ~= false
+        and type(m.operator) ~= 'string'
+      then
+        warn('mappings.operator', 'string or false', type(m.operator))
+        m.operator = nil
+      end
+      local sub_keys = {
+        textobject = { 'inner', 'around' },
+        motion = { 'next_delimiter', 'prev_delimiter' },
+      }
+      for group, keys in pairs(sub_keys) do
+        if m[group] ~= nil and m[group] ~= false then
+          if type(m[group]) ~= 'table' then
+            warn('mappings.' .. group, 'table or false', type(m[group]))
+            m[group] = nil
+          else
+            for _, k in ipairs(keys) do
+              if m[group][k] ~= nil and type(m[group][k]) ~= 'string' then
+                warn(
+                  'mappings.' .. group .. '.' .. k,
+                  'string',
+                  type(m[group][k])
+                )
+                m[group][k] = nil
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
 --- Get user config.
@@ -101,7 +141,7 @@ end
 --- @param overrides? Config
 --- @return Config user_config
 M.setup = function(overrides)
-  overrides = overrides or {}
+  overrides = vim.deepcopy(overrides or {})
   validate(overrides)
   user_config = vim.tbl_deep_extend('force', user_config, overrides)
 

--- a/lua/sort/mappings.lua
+++ b/lua/sort/mappings.lua
@@ -12,6 +12,7 @@ local function setup_operator_mappings(mappings)
 
   -- Normal mode operator mapping.
   vim.keymap.set('n', operator_key, function()
+    operator.capture_options()
     vim.o.operatorfunc = 'v:lua._sort_operator'
     return 'g@'
   end, {
@@ -59,6 +60,7 @@ local function setup_operator_mappings(mappings)
     vim.api.nvim_buf_set_mark(0, '>', end_row, end_col - 1, {})
 
     -- Call the operator with visual mode flag.
+    operator.capture_options()
     operator.sort_operator(detected_mode, true)
   end, {
     desc = 'Sort selection',
@@ -67,6 +69,7 @@ local function setup_operator_mappings(mappings)
 
   -- Line-wise shortcut (operator + operator = line).
   vim.keymap.set('n', operator_key .. operator_key, function()
+    operator.capture_options()
     vim.o.operatorfunc = 'v:lua._sort_operator'
     return 'g@_'
   end, {

--- a/lua/sort/operator.lua
+++ b/lua/sort/operator.lua
@@ -3,6 +3,34 @@ local utils = require('sort.utils')
 
 local M = {}
 
+-- Snapshot of user options captured when the operator is invoked via a
+-- keymap. Dot-repeat calls the operatorfunc directly without re-running the
+-- keymap expression, so reading live config there would diverge from the
+-- invocation. Capturing here keeps vim-repeat semantics: `.` reproduces the
+-- action with the options active at first press.
+local captured_options = nil
+
+local function snapshot_user_options()
+  local config = require('sort.config')
+  local user_config = config.get_user_config()
+  return {
+    natural = user_config.natural_sort,
+    ignore_case = user_config.ignore_case,
+    unique = user_config.unique,
+  }
+end
+
+--- Capture the current config as a snapshot for subsequent sort_operator
+--- calls (including dot-repeat). Called by operator keymaps before g@ fires.
+M.capture_options = function()
+  captured_options = snapshot_user_options()
+end
+
+--- Clear the captured options snapshot. Test helper.
+M.reset_captured_options = function()
+  captured_options = nil
+end
+
 --- Get text based on motion type and marks.
 --- @param motion_type string Motion type ('line', 'char', 'block')
 --- @param start_pos table Start position [row, col]
@@ -313,11 +341,10 @@ M.sort_operator = function(motion_type, from_visual)
 
   local options = utils.parse_arguments('', '')
 
-  local config = require('sort.config')
-  local user_config = config.get_user_config()
-  options.natural = user_config.natural_sort
-  options.ignore_case = user_config.ignore_case
-  options.unique = user_config.unique
+  local snapshot = captured_options or snapshot_user_options()
+  options.natural = snapshot.natural
+  options.ignore_case = snapshot.ignore_case
+  options.unique = snapshot.unique
 
   local sorted_text
   local lines = vim.split(text, '\n')

--- a/lua/sort/operator.lua
+++ b/lua/sort/operator.lua
@@ -313,20 +313,11 @@ M.sort_operator = function(motion_type, from_visual)
       local ends_at_line_end = end_pos[2] >= string.len(last_line) - 1
         or string.match(after_selection, '^[%s,;%]%)%}]*$')
 
-      -- For selections spanning 3+ lines, be more lenient - treat as line motion
-      -- if at least one boundary looks like a line boundary. This handles text
-      -- objects like `ii` (inside indent) that may not start at column 0 but
-      -- still represent a logical line selection.
-      local spans_many_lines = (end_pos[1] - start_pos[1]) >= 2
-
-      -- Treat as line motion if:
-      -- 1. "Perfect lines" selection (starts at beginning, ends at line end)
-      -- 2. Multi-line text objects that cover mostly complete lines
-      local is_perfect_lines = starts_at_line_beginning and ends_at_line_end
-      local is_multiline_block = spans_many_lines
-        and (starts_at_line_beginning or ends_at_line_end)
-
-      if is_perfect_lines or is_multiline_block then
+      -- Promote to line motion only when BOTH boundaries look line-shaped.
+      -- A one-sided match (e.g. starts at col 0 but ends mid-line) is a
+      -- deliberate partial selection — widening it silently would discard
+      -- characters the user intended to keep.
+      if starts_at_line_beginning and ends_at_line_end then
         effective_motion_type = 'line'
       end
     end

--- a/lua/sort/operator.lua
+++ b/lua/sort/operator.lua
@@ -256,6 +256,11 @@ end
 --- @param motion_type string Motion type from operatorfunc
 --- @param from_visual boolean|nil Whether called from visual mode
 M.sort_operator = function(motion_type, from_visual)
+  if not vim.bo.modifiable then
+    vim.notify('Buffer is not modifiable', vim.log.levels.WARN)
+    return
+  end
+
   local start_pos, end_pos, is_visual_marks
 
   if from_visual then

--- a/lua/sort/sort.lua
+++ b/lua/sort/sort.lua
@@ -97,16 +97,17 @@ M.delimiter_sort = function(text, options)
     local trailing_ws = utils.get_trailing_whitespace(match)
     local trimmed = utils.trim_leading_and_trailing_whitespace(match)
 
-    -- Skip structural trailing empty segment when:
-    -- 1. We have a trailing delimiter but no leading delimiter
-    -- 2. This is the last segment and it's empty
-    -- 3. This indicates the empty segment is structural, not content
+    -- Drop structural empty segments at the boundaries: when text begins or
+    -- ends with the delimiter, split yields a sentinel empty we re-prepend
+    -- or re-append below. Keeping it causes duplicate delimiters in output.
+    local is_structural_leading_empty = has_leading_delimiter
+      and i == 1
+      and match == ''
     local is_structural_trailing_empty = has_trailing_delimiter
-      and not has_leading_delimiter
       and i == #matches
       and match == ''
 
-    if not is_structural_trailing_empty then
+    if not is_structural_trailing_empty and not is_structural_leading_empty then
       if trimmed == '' and top_translated_delimiter ~= ' ' then
         -- For other delimiters, preserve whitespace-only segments.
         table.insert(items, {

--- a/lua/sort/sort.lua
+++ b/lua/sort/sort.lua
@@ -68,10 +68,9 @@ M.delimiter_sort = function(text, options)
     matches = utils.split_by_delimiter(text, top_translated_delimiter)
 
     if #matches > 1 then
-      has_leading_delimiter =
-        string.match(text, '^' .. top_translated_delimiter)
-      has_trailing_delimiter =
-        string.match(text, top_translated_delimiter .. '$')
+      local escaped = vim.pesc(top_translated_delimiter)
+      has_leading_delimiter = string.match(text, '^' .. escaped)
+      has_trailing_delimiter = string.match(text, escaped .. '$')
       break
     end
   end

--- a/lua/sort/sort.lua
+++ b/lua/sort/sort.lua
@@ -69,8 +69,8 @@ M.delimiter_sort = function(text, options)
 
     if #matches > 1 then
       local escaped = vim.pesc(top_translated_delimiter)
-      has_leading_delimiter = string.match(text, '^' .. escaped)
-      has_trailing_delimiter = string.match(text, escaped .. '$')
+      has_leading_delimiter = string.match(text, '^' .. escaped) ~= nil
+      has_trailing_delimiter = string.match(text, escaped .. '$') ~= nil
       break
     end
   end

--- a/lua/sort/sort.lua
+++ b/lua/sort/sort.lua
@@ -128,6 +128,12 @@ M.delimiter_sort = function(text, options)
     end
   end
 
+  -- Capture outer whitespace from the original input. When items reorder,
+  -- the outer leading/trailing belongs to the text, not to whichever item
+  -- was originally at position 1/N — so we re-apply it after normalization.
+  local outer_leading_ws = items[1] and items[1].leading_ws or ''
+  local outer_trailing_ws = items[#items] and items[#items].trailing_ws or ''
+
   -- Check if sorting will change the order.
   local original_order = {}
   for i, item in ipairs(items) do
@@ -222,20 +228,30 @@ M.delimiter_sort = function(text, options)
       top_translated_delimiter
     )
 
-    -- Normalize whitespace for each item.
-    for i, item in ipairs(items) do
+    -- Normalize whitespace for each item. Every item is treated identically:
+    -- short leading whitespace is replaced with the dominant pattern; whitespace
+    -- at or above the alignment threshold is preserved as deliberate column
+    -- alignment. trailing_ws is cleared so inter-item spacing lives entirely in
+    -- the next item's leading_ws, yielding an identical gap between every pair.
+    for _, item in ipairs(items) do
       if item.trimmed ~= '' then
-        -- For comma-separated values, first item should have no leading whitespace.
-        if i == 1 and top_translated_delimiter == ',' then
-          item.leading_ws = ''
-        else
-          item.leading_ws = utils.normalize_whitespace(
-            item.leading_ws,
-            dominant_pattern,
-            alignment_threshold
-          )
-        end
+        item.leading_ws = utils.normalize_whitespace(
+          item.leading_ws,
+          dominant_pattern,
+          alignment_threshold
+        )
+        item.trailing_ws = ''
       end
+    end
+
+    -- Re-apply the input's outer leading/trailing to the boundary items so
+    -- input `'x,y'` does not gain leading whitespace and input `' x,y '` keeps
+    -- its outer whitespace regardless of which item lands at each end.
+    if items[1] and items[1].trimmed ~= '' then
+      items[1].leading_ws = outer_leading_ws
+    end
+    if items[#items] and items[#items].trimmed ~= '' then
+      items[#items].trailing_ws = outer_trailing_ws
     end
   end
 

--- a/lua/sort/textobjects.lua
+++ b/lua/sort/textobjects.lua
@@ -6,7 +6,7 @@ local M = {}
 --- Find the boundaries of a sortable region around the cursor.
 --- @param include_delimiters boolean Whether to include surrounding delimiters
 --- @return table|nil selection Selection object or nil if no sortable region found
-M._find_sortable_region = function(include_delimiters)
+function M._find_sortable_region(include_delimiters)
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local row = cursor_pos[1]
   local col = cursor_pos[2] + 1 -- Convert to 1-based indexing
@@ -102,7 +102,7 @@ end
 --- the user into normal mode; set `<`/`>` marks and reselect with `gv` instead.
 --- @param selection table Selection with from/to row and column
 --- @param mode string Mode letter from vim.api.nvim_get_mode().mode
-M._apply_selection = function(selection, mode)
+function M._apply_selection(selection, mode)
   local row = selection.from.row
   local start_col_zero = selection.from.column - 1
   local end_col_zero = selection.to.column - 1
@@ -121,7 +121,7 @@ M._apply_selection = function(selection, mode)
 end
 
 --- Select inner sortable region (without delimiters).
-M.select_inner = function()
+function M.select_inner()
   local selection = M._find_sortable_region(false)
 
   if not selection then
@@ -138,7 +138,7 @@ M.select_inner = function()
 end
 
 --- Select around sortable region (with delimiters).
-M.select_around = function()
+function M.select_around()
   local selection = M._find_sortable_region(true)
 
   if not selection then

--- a/lua/sort/textobjects.lua
+++ b/lua/sort/textobjects.lua
@@ -61,16 +61,27 @@ function M._find_sortable_region(include_delimiters)
   end
 
   if segment_index == nil then
-    -- Cursor on a delimiter or past the last segment. Snap to the segment
-    -- whose end lies immediately before the cursor; fall back to the first.
+    -- Cursor on a delimiter or past the last segment. Empty boundary
+    -- segments (from leading/trailing delimiters) have finish < start and
+    -- must be skipped — otherwise the returned selection has to < from.
     for i = #segments, 1, -1 do
-      if segments[i].finish < col then
+      if
+        segments[i].finish >= segments[i].start and segments[i].finish < col
+      then
         segment_index = i
         break
       end
     end
     if segment_index == nil then
-      segment_index = 1
+      for i = 1, #segments do
+        if segments[i].finish >= segments[i].start then
+          segment_index = i
+          break
+        end
+      end
+    end
+    if segment_index == nil then
+      return nil
     end
   end
 

--- a/lua/sort/textobjects.lua
+++ b/lua/sort/textobjects.lua
@@ -6,7 +6,7 @@ local M = {}
 --- Find the boundaries of a sortable region around the cursor.
 --- @param include_delimiters boolean Whether to include surrounding delimiters
 --- @return table|nil selection Selection object or nil if no sortable region found
-local function find_sortable_region(include_delimiters)
+M._find_sortable_region = function(include_delimiters)
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local row = cursor_pos[1]
   local col = cursor_pos[2] + 1 -- Convert to 1-based indexing
@@ -40,23 +40,42 @@ local function find_sortable_region(include_delimiters)
     return nil
   end
 
-  -- Find which segment the cursor is in.
+  -- Compute every segment's [start, finish] up front so we can snap deterministically
+  -- when the cursor sits on a delimiter or past the last segment.
+  local segments = {}
   local current_pos = 1
-  local segment_start = 1
-  local segment_end = 1
-  local segment_index = 1
-
   for i, match in ipairs(matches) do
-    segment_start = current_pos
-    segment_end = current_pos + string.len(match) - 1
+    segments[i] = {
+      start = current_pos,
+      finish = current_pos + string.len(match) - 1,
+    }
+    current_pos = current_pos + string.len(match) + string.len(best_delimiter)
+  end
 
-    if col >= segment_start and col <= segment_end then
+  local segment_index = nil
+  for i, seg in ipairs(segments) do
+    if col >= seg.start and col <= seg.finish then
       segment_index = i
       break
     end
-
-    current_pos = current_pos + string.len(match) + string.len(best_delimiter)
   end
+
+  if segment_index == nil then
+    -- Cursor on a delimiter or past the last segment. Snap to the segment
+    -- whose end lies immediately before the cursor; fall back to the first.
+    for i = #segments, 1, -1 do
+      if segments[i].finish < col then
+        segment_index = i
+        break
+      end
+    end
+    if segment_index == nil then
+      segment_index = 1
+    end
+  end
+
+  local segment_start = segments[segment_index].start
+  local segment_end = segments[segment_index].finish
 
   -- Determine selection boundaries.
   local selection_start = segment_start
@@ -80,7 +99,7 @@ end
 
 --- Select inner sortable region (without delimiters).
 M.select_inner = function()
-  local selection = find_sortable_region(false)
+  local selection = M._find_sortable_region(false)
 
   if not selection then
     vim.notify('No sortable region found around cursor', vim.log.levels.WARN)
@@ -102,7 +121,7 @@ end
 
 --- Select around sortable region (with delimiters).
 M.select_around = function()
-  local selection = find_sortable_region(true)
+  local selection = M._find_sortable_region(true)
 
   if not selection then
     vim.notify('No sortable region found around cursor', vim.log.levels.WARN)

--- a/lua/sort/textobjects.lua
+++ b/lua/sort/textobjects.lua
@@ -97,6 +97,29 @@ M._find_sortable_region = function(include_delimiters)
   }
 end
 
+--- Apply a selection using the right mechanism for the given editor mode.
+--- In visual modes (v/V/<C-v>), `normal! v` would toggle visual off and drop
+--- the user into normal mode; set `<`/`>` marks and reselect with `gv` instead.
+--- @param selection table Selection with from/to row and column
+--- @param mode string Mode letter from vim.api.nvim_get_mode().mode
+M._apply_selection = function(selection, mode)
+  local row = selection.from.row
+  local start_col_zero = selection.from.column - 1
+  local end_col_zero = selection.to.column - 1
+
+  local is_visual = mode == 'v' or mode == 'V' or mode == '\22'
+  if is_visual then
+    vim.fn.setpos("'<", { 0, row, selection.from.column, 0 })
+    vim.fn.setpos("'>", { 0, row, selection.to.column, 0 })
+    vim.cmd('normal! gv')
+    return
+  end
+
+  vim.api.nvim_win_set_cursor(0, { row, start_col_zero })
+  vim.cmd('normal! v')
+  vim.api.nvim_win_set_cursor(0, { row, end_col_zero })
+end
+
 --- Select inner sortable region (without delimiters).
 M.select_inner = function()
   local selection = M._find_sortable_region(false)
@@ -111,12 +134,7 @@ M.select_inner = function()
     return
   end
 
-  local start_pos = { selection.from.row, selection.from.column - 1 }
-  local end_pos = { selection.to.row, selection.to.column - 1 }
-
-  vim.api.nvim_win_set_cursor(0, start_pos)
-  vim.cmd('normal! v')
-  vim.api.nvim_win_set_cursor(0, end_pos)
+  M._apply_selection(selection, vim.api.nvim_get_mode().mode)
 end
 
 --- Select around sortable region (with delimiters).
@@ -133,12 +151,7 @@ M.select_around = function()
     return
   end
 
-  local start_pos = { selection.from.row, selection.from.column - 1 }
-  local end_pos = { selection.to.row, selection.to.column - 1 }
-
-  vim.api.nvim_win_set_cursor(0, start_pos)
-  vim.cmd('normal! v')
-  vim.api.nvim_win_set_cursor(0, end_pos)
+  M._apply_selection(selection, vim.api.nvim_get_mode().mode)
 end
 
 return M

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -188,6 +188,13 @@ M.parse_arguments = function(bang, arguments)
       options.unique = true
     elseif c == 'z' then
       options.natural = true
+    elseif c == 's' or c == 't' then
+      vim.notify(
+        "sort.nvim: '"
+          .. c
+          .. "' delimiter shortcut must be standalone, not combined with flags",
+        vim.log.levels.WARN
+      )
     elseif string.match(c, '%p') then
       options.delimiter = options.delimiter or c
     else

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -89,19 +89,20 @@ end
 M.parse_number = function(text, base)
   base = base or 10
 
-  -- Define patterns for different number bases.
+  -- Anchored patterns: the whole input must be a valid number in the given base.
+  -- Unanchored patterns would match embedded digit runs, e.g. '5xyz' as 5.
   local patterns = {
-    [2] = '%-?[01]+',
-    [8] = '%-?[0-7]+',
-    [10] = '%-?[%d.]+',
-    [16] = '%-?0[xX]%x+',
+    [2] = '^%-?[01]+$',
+    [8] = '^%-?[0-7]+$',
+    [10] = '^%-?[%d.]+$',
+    [16] = '^%-?0[xX]%x+$',
   }
 
   local match = string.match(text, patterns[base] or patterns[10])
 
   -- For hexadecimal, also try pattern without 0x prefix.
   if base == 16 and not match then
-    match = string.match(text, '%-?%x+')
+    match = string.match(text, '^%-?%x+$')
   end
 
   return tonumber(match or '', base ~= 10 and base or nil)

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -21,7 +21,10 @@ M.get_trailing_whitespace = function(text)
   return trailing_whitespace or ''
 end
 
---- Split by translated delimiter.
+--- Split by translated delimiter. Splitting is always literal — quoted
+--- strings (`"a,b",c`) and bracket-protected regions (`(a,b),c`) are not
+--- honored, even when the delimiter appears inside them. See README
+--- "Limitations".
 --- @param text string
 --- @param translated_delimiter string
 --- @return string[] matches

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -204,9 +204,7 @@ M.parse_natural_segments = function(str)
 
   -- Leading '-' before digits is a sign, not a separator. Mid-string '-' keeps
   -- its separator semantics (see "dashes as separators" in natural sort).
-  if
-    str:sub(1, 1) == '-' and string.match(str:sub(2, 2) or '', '%d') ~= nil
-  then
+  if str:sub(1, 1) == '-' and string.match(str:sub(2, 2), '%d') ~= nil then
     local j = 2
     while j <= #str and string.match(str:sub(j, j), '%d') do
       j = j + 1

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -512,14 +512,22 @@ M.all_pure_numbers = function(items)
   return true
 end
 
+--- Empty strings sort after all numeric values so they cluster at one end
+--- instead of slotting between negatives and positives as coerced zeros.
 --- Falls back to string comparison if tonumber fails (should not occur when
 --- called via the sorting pipeline which pre-validates with all_pure_numbers).
 --- @param a string
 --- @param b string
 --- @return boolean
 M.math_compare = function(a, b)
-  local na = a == '' and 0 or tonumber(a)
-  local nb = b == '' and 0 or tonumber(b)
+  if a == '' then
+    return false
+  end
+  if b == '' then
+    return true
+  end
+  local na = tonumber(a)
+  local nb = tonumber(b)
   if na and nb then
     return na < nb
   end

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -149,33 +149,53 @@ M.split_by_delimiter = function(text, translated_delimiter)
 end
 
 --- Parse options provided via bang and/or arguments.
+---
+--- Flag letters ({b, n, o, x, i, u, z}) bind first, so combining them with
+--- other characters doesn't accidentally consume a letter as a delimiter.
+--- `s` and `t` only map to space/tab delimiters when they stand alone;
+--- combined with other flags they would collide with the flag letter
+--- parsing, so they're rejected with a warning instead.
+---
 --- @param bang string
 --- @param arguments string
 --- @return SortOptions options
 M.parse_arguments = function(bang, arguments)
-  local delimiter_pattern = '[st%p]'
-  local numerical_pattern = '[bnox]'
-  local options = {}
+  local numerical_map = { b = 2, n = 10, o = 8, x = 16 }
+  local options = {
+    numerical = false,
+    ignore_case = false,
+    unique = false,
+    natural = false,
+    reverse = bang == '!',
+  }
 
-  options.delimiter = string.match(arguments, delimiter_pattern)
-
-  local numerical = string.match(arguments, numerical_pattern)
-  if numerical == 'b' then
-    options.numerical = 2
-  elseif numerical == 'o' then
-    options.numerical = 8
-  elseif numerical == 'x' then
-    options.numerical = 16
-  elseif numerical == 'n' then
-    options.numerical = 10
-  else
-    options.numerical = false
+  -- Standalone 's' or 't' is a delimiter (space/tab shortcut).
+  if arguments == 's' or arguments == 't' then
+    options.delimiter = arguments
+    return options
   end
 
-  options.ignore_case = string.match(arguments, 'i') ~= nil
-  options.reverse = bang == '!'
-  options.unique = string.match(arguments, 'u') ~= nil
-  options.natural = string.match(arguments, 'z') ~= nil
+  for i = 1, #arguments do
+    local c = string.sub(arguments, i, i)
+    if numerical_map[c] then
+      if options.numerical == false then
+        options.numerical = numerical_map[c]
+      end
+    elseif c == 'i' then
+      options.ignore_case = true
+    elseif c == 'u' then
+      options.unique = true
+    elseif c == 'z' then
+      options.natural = true
+    elseif string.match(c, '%p') then
+      options.delimiter = options.delimiter or c
+    else
+      vim.notify(
+        "sort.nvim: unknown flag '" .. c .. "' in arguments",
+        vim.log.levels.WARN
+      )
+    end
+  end
 
   return options
 end

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -505,16 +505,25 @@ M.normalize_whitespace = function(
   return dominant_pattern
 end
 
---- Rejects '.5', accepts '0.5' and '5.'.
+--- Accepts optional sign, with digits before or after the decimal point,
+--- with optional scientific exponent. Requires at least one digit, so `.`
+--- alone and `e5` fail. `tonumber` is the final guard.
 --- @param str string
 --- @return boolean
 M.is_pure_number = function(str)
   if str == nil or str == '' then
     return false
   end
-  local has_basic_number = string.match(str, '^[%+%-]?%d+%.?%d*$') ~= nil
-  local has_scientific = string.match(str, '^[%+%-]?%d+%.?%d*[eE][%+%-]?%d+$')
-    ~= nil
+  -- Lua patterns have no alternation, so match the two mantissa shapes
+  -- separately: digits-first (`5`, `5.`, `5.5`) and dot-first (`.5`).
+  local digits_first = '[%+%-]?%d+%.?%d*'
+  local dot_first = '[%+%-]?%.%d+'
+  local has_basic_number = string.match(str, '^' .. digits_first .. '$') ~= nil
+    or string.match(str, '^' .. dot_first .. '$') ~= nil
+  local has_scientific = string.match(
+    str,
+    '^' .. digits_first .. '[eE][%+%-]?%d+$'
+  ) ~= nil or string.match(str, '^' .. dot_first .. '[eE][%+%-]?%d+$') ~= nil
   return (has_basic_number or has_scientific) and tonumber(str) ~= nil
 end
 

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -202,6 +202,23 @@ M.parse_natural_segments = function(str)
   local segments = {}
   local i = 1
 
+  -- Leading '-' before digits is a sign, not a separator. Mid-string '-' keeps
+  -- its separator semantics (see "dashes as separators" in natural sort).
+  if
+    str:sub(1, 1) == '-' and string.match(str:sub(2, 2) or '', '%d') ~= nil
+  then
+    local j = 2
+    while j <= #str and string.match(str:sub(j, j), '%d') do
+      j = j + 1
+    end
+    table.insert(segments, {
+      text = str:sub(1, j - 1),
+      is_number = true,
+      is_punctuation = false,
+    })
+    i = j
+  end
+
   while i <= #str do
     local start = i
     local current_char = str:sub(i, i)

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -1,24 +1,119 @@
 local M = {}
 
-local leading_whitespace_pattern = '^%s+'
-local trailing_whitespace_pattern = '%s+$'
+-- UTF-8 byte sequences for Unicode whitespace characters outside Lua's %s class.
+-- Covers Unicode White_Space (excluding ASCII already in %s).
+local unicode_whitespace = {
+  ['\194\160'] = true, -- U+00A0 NBSP
+  ['\225\154\128'] = true, -- U+1680 Ogham space mark
+  ['\226\128\128'] = true, -- U+2000 en quad
+  ['\226\128\129'] = true, -- U+2001 em quad
+  ['\226\128\130'] = true, -- U+2002 en space
+  ['\226\128\131'] = true, -- U+2003 em space
+  ['\226\128\132'] = true, -- U+2004 three-per-em space
+  ['\226\128\133'] = true, -- U+2005 four-per-em space
+  ['\226\128\134'] = true, -- U+2006 six-per-em space
+  ['\226\128\135'] = true, -- U+2007 figure space
+  ['\226\128\136'] = true, -- U+2008 punctuation space
+  ['\226\128\137'] = true, -- U+2009 thin space
+  ['\226\128\138'] = true, -- U+200A hair space
+  ['\226\128\168'] = true, -- U+2028 line separator
+  ['\226\128\169'] = true, -- U+2029 paragraph separator
+  ['\226\128\175'] = true, -- U+202F narrow NBSP
+  ['\226\129\159'] = true, -- U+205F medium math space
+  ['\227\128\128'] = true, -- U+3000 ideographic space
+}
+
+--- Byte length of one whitespace character at position `pos`, or 0 if the
+--- character at `pos` is not whitespace.
+--- @param text string
+--- @param pos integer 1-based byte index
+--- @return integer width
+local function whitespace_width(text, pos)
+  local b = string.byte(text, pos)
+  if not b then
+    return 0
+  end
+  -- ASCII whitespace: space, tab, LF, VT, FF, CR.
+  if b == 32 or (b >= 9 and b <= 13) then
+    return 1
+  end
+  if b < 0x80 then
+    return 0
+  end
+  local width
+  if b < 0xE0 then
+    width = 2
+  elseif b < 0xF0 then
+    width = 3
+  else
+    width = 4
+  end
+  local char = string.sub(text, pos, pos + width - 1)
+  if unicode_whitespace[char] then
+    return width
+  end
+  return 0
+end
+
+--- Byte length of the leading whitespace run.
+--- @param text string
+--- @return integer
+local function leading_whitespace_length(text)
+  local pos = 1
+  while pos <= #text do
+    local w = whitespace_width(text, pos)
+    if w == 0 then
+      break
+    end
+    pos = pos + w
+  end
+  return pos - 1
+end
+
+--- Start byte index (1-based) of the trailing whitespace run, or #text + 1 if
+--- there is none. A single forward scan finds the last non-whitespace byte.
+--- @param text string
+--- @return integer
+local function trailing_whitespace_start(text)
+  local pos = 1
+  local last_non_ws_end = 0
+  while pos <= #text do
+    local b = string.byte(text, pos)
+    if not b then
+      break
+    end
+    local width
+    if b < 0x80 then
+      width = 1
+    elseif b < 0xE0 then
+      width = 2
+    elseif b < 0xF0 then
+      width = 3
+    else
+      width = 4
+    end
+    local char = string.sub(text, pos, pos + width - 1)
+    local is_ws = (b == 32 or (b >= 9 and b <= 13)) or unicode_whitespace[char]
+    if not is_ws then
+      last_non_ws_end = pos + width - 1
+    end
+    pos = pos + width
+  end
+  return last_non_ws_end + 1
+end
 
 --- Get leading whitespaces.
 --- @param text string
 --- @return string
 M.get_leading_whitespace = function(text)
-  local leading_whitespace = string.match(text, leading_whitespace_pattern)
-
-  return leading_whitespace or ''
+  return string.sub(text, 1, leading_whitespace_length(text))
 end
 
 --- Get trailing whitespaces.
 --- @param text string
 --- @return string
 M.get_trailing_whitespace = function(text)
-  local trailing_whitespace = string.match(text, trailing_whitespace_pattern)
-
-  return trailing_whitespace or ''
+  return string.sub(text, trailing_whitespace_start(text))
 end
 
 --- Split by translated delimiter. Splitting is always literal — quoted
@@ -127,10 +222,12 @@ end
 --- @param text string
 --- @return string
 M.trim_leading_and_trailing_whitespace = function(text)
-  text = string.gsub(text, leading_whitespace_pattern, '')
-  text = string.gsub(text, trailing_whitespace_pattern, '')
-
-  return text
+  local leading = leading_whitespace_length(text)
+  local trailing_start = trailing_whitespace_start(text)
+  if trailing_start <= leading then
+    return ''
+  end
+  return string.sub(text, leading + 1, trailing_start - 1)
 end
 
 --- Detect the dominant whitespace pattern from a list of whitespace strings.

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -3,6 +3,7 @@ local M = {}
 -- UTF-8 byte sequences for Unicode whitespace characters outside Lua's %s class.
 -- Covers Unicode White_Space (excluding ASCII already in %s).
 local unicode_whitespace = {
+  ['\194\133'] = true, -- U+0085 NEL (Next Line)
   ['\194\160'] = true, -- U+00A0 NBSP
   ['\225\154\128'] = true, -- U+1680 Ogham space mark
   ['\226\128\128'] = true, -- U+2000 en quad

--- a/lua/sort/utils.lua
+++ b/lua/sort/utils.lua
@@ -352,6 +352,21 @@ M.natural_compare = function(a, b, ignore_case)
 end
 
 --- Normalize whitespace for a segment based on configuration.
+---
+--- Whitespace policy for delimiter_sort:
+---   - Items carry their own leading_ws and trailing_ws; whitespace "moves with
+---     the item" when items reorder.
+---   - When order changes (and natural_sort is disabled), every item's
+---     leading_ws is passed through this function uniformly — no positional
+---     special-casing. Natural sort preserves whitespace verbatim to protect
+---     intentional column alignment.
+---   - This function only normalizes leading_ws. The caller zeros trailing_ws
+---     directly so all inter-item whitespace lives in the next item's
+---     leading_ws.
+---   - Whitespace at or above `alignment_threshold` chars is preserved as
+---     deliberate column alignment. Shorter whitespace is replaced with the
+---     dominant pattern detected across items.
+---
 --- @param original_whitespace string
 --- @param dominant_pattern string
 --- @param alignment_threshold number

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -185,5 +185,15 @@ describe('config', function()
 
       assert.are.equal(true, user_config.natural_sort)
     end)
+
+    it('should preserve prior keys across layered setup calls', function()
+      config.setup({ ignore_case = true })
+      config.setup({ unique = true })
+
+      local user_config = config.get_user_config()
+
+      assert.are.equal(true, user_config.ignore_case)
+      assert.are.equal(true, user_config.unique)
+    end)
   end)
 end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -280,5 +280,84 @@ describe('config', function()
       assert.are.equal('gS', user_config.keymap)
       assert.are.equal(true, user_config.natural_sort)
     end)
+
+    it('should reject non-table mappings and keep defaults', function()
+      config.setup({ mappings = 42 })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('go', user_config.mappings.operator)
+      assert.is_true(#notify_calls >= 1)
+      assert.is_true(
+        string.find(notify_calls[1].msg, 'mappings', 1, true) ~= nil
+      )
+    end)
+
+    it('should accept false for mappings to disable', function()
+      config.setup({ mappings = false })
+      local user_config = config.get_user_config()
+
+      assert.are.equal(false, user_config.mappings)
+      assert.are.equal(0, #notify_calls)
+    end)
+
+    it('should reject non-string mappings.operator', function()
+      config.setup({ mappings = { operator = 42 } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('go', user_config.mappings.operator)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should accept false for mappings.operator to disable', function()
+      config.setup({ mappings = { operator = false } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal(false, user_config.mappings.operator)
+      assert.are.equal(0, #notify_calls)
+    end)
+
+    it('should reject non-table mappings.textobject', function()
+      config.setup({ mappings = { textobject = 'nope' } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('is', user_config.mappings.textobject.inner)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should reject non-string mappings.textobject.inner', function()
+      config.setup({ mappings = { textobject = { inner = 42 } } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('is', user_config.mappings.textobject.inner)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should reject non-string mappings.motion.next_delimiter', function()
+      config.setup({ mappings = { motion = { next_delimiter = true } } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal(']s', user_config.mappings.motion.next_delimiter)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should accept valid mappings without warnings', function()
+      config.setup({
+        mappings = {
+          operator = 'gS',
+          textobject = { inner = 'iS', around = 'aS' },
+          motion = { next_delimiter = ']S', prev_delimiter = '[S' },
+        },
+      })
+
+      assert.are.equal(0, #notify_calls)
+    end)
+
+    it('should not mutate the overrides table passed in', function()
+      local overrides = { natural_sort = 'bogus', keymap = 42 }
+      config.setup(overrides)
+
+      assert.are.equal('bogus', overrides.natural_sort)
+      assert.are.equal(42, overrides.keymap)
+    end)
   end)
 end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -196,4 +196,89 @@ describe('config', function()
       assert.are.equal(true, user_config.unique)
     end)
   end)
+
+  describe('setup validation', function()
+    local original_notify
+    local notify_calls
+
+    before_each(function()
+      original_notify = vim.notify
+      notify_calls = {}
+      vim.notify = function(msg, level)
+        notify_calls[#notify_calls + 1] = { msg = msg, level = level }
+      end
+    end)
+
+    -- selene: allow(undefined_variable)
+    after_each(function()
+      vim.notify = original_notify
+    end)
+
+    it('should reject non-table delimiters and keep default', function()
+      config.setup({ delimiters = 123 })
+      local user_config = config.get_user_config()
+
+      assert.are.same({ ',', '|', ';', ':', 's', 't' }, user_config.delimiters)
+      assert.is_true(#notify_calls >= 1)
+      assert.is_true(
+        string.find(notify_calls[1].msg, 'delimiters', 1, true) ~= nil
+      )
+    end)
+
+    it('should reject negative alignment_threshold', function()
+      config.setup({ whitespace = { alignment_threshold = -5 } })
+      local user_config = config.get_user_config()
+
+      assert.are.equal(3, user_config.whitespace.alignment_threshold)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should reject non-boolean natural_sort', function()
+      config.setup({ natural_sort = 'hello' })
+      local user_config = config.get_user_config()
+
+      assert.are.equal(true, user_config.natural_sort)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should reject non-string keymap', function()
+      config.setup({ keymap = 42 })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('go', user_config.keymap)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should reject delimiters list with non-string element', function()
+      config.setup({ delimiters = { ',', 5, ';' } })
+      local user_config = config.get_user_config()
+
+      assert.are.same({ ',', '|', ';', ':', 's', 't' }, user_config.delimiters)
+      assert.is_true(#notify_calls >= 1)
+    end)
+
+    it('should accept valid full config without warnings', function()
+      config.setup({
+        delimiters = { ',', '|' },
+        keymap = 'gS',
+        natural_sort = false,
+        ignore_case = true,
+        unique = true,
+        whitespace = { alignment_threshold = 5 },
+      })
+
+      assert.are.equal(0, #notify_calls)
+    end)
+
+    it('should apply valid keys even when another key is invalid', function()
+      config.setup({
+        keymap = 'gS',
+        natural_sort = 'bogus',
+      })
+      local user_config = config.get_user_config()
+
+      assert.are.equal('gS', user_config.keymap)
+      assert.are.equal(true, user_config.natural_sort)
+    end)
+  end)
 end)

--- a/tests/features/dot_repeat_spec.lua
+++ b/tests/features/dot_repeat_spec.lua
@@ -122,6 +122,82 @@ describe('dot repeat functionality', function()
     end)
   end)
 
+  describe('config snapshot for dot-repeat (main-vps)', function()
+    local original_user_config
+
+    before_each(function()
+      local config = require('sort.config')
+      original_user_config = vim.deepcopy(config.get_user_config())
+      local op = require('sort.operator')
+      if op.reset_captured_options then
+        op.reset_captured_options()
+      end
+    end)
+
+    -- selene: allow(undefined_variable)
+    after_each(function()
+      local config = require('sort.config')
+      config.setup(original_user_config)
+      local op = require('sort.operator')
+      if op.reset_captured_options then
+        op.reset_captured_options()
+      end
+    end)
+
+    it(
+      'should use snapshot from invocation, not live config, on dot-repeat',
+      function()
+        local config = require('sort.config')
+        local op = require('sort.operator')
+        setup_buffer({ 'b, a, a, c', 'c, b, a, a' })
+
+        config.setup({ unique = false })
+
+        op.capture_options()
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        set_operator_marks(1, 1, 1, 10)
+        op.sort_operator('char', false)
+
+        local result = get_buffer_content()
+        assert.are.equal('a, a, b, c', result[1])
+
+        config.setup({ unique = true })
+
+        set_operator_marks(2, 1, 2, 10)
+        op.sort_operator('char', false)
+
+        result = get_buffer_content()
+        assert.are.equal('a, a, b, c', result[2])
+      end
+    )
+
+    it(
+      'should refresh snapshot on each new invocation (not dot-repeat)',
+      function()
+        local config = require('sort.config')
+        local op = require('sort.operator')
+        setup_buffer({ 'b, a, a, c', 'c, b, a, a' })
+
+        config.setup({ unique = false })
+        op.capture_options()
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        set_operator_marks(1, 1, 1, 10)
+        op.sort_operator('char', false)
+
+        local result = get_buffer_content()
+        assert.are.equal('a, a, b, c', result[1])
+
+        config.setup({ unique = true })
+        op.capture_options()
+        set_operator_marks(2, 1, 2, 10)
+        op.sort_operator('char', false)
+
+        result = get_buffer_content()
+        assert.are.equal('a, b, c', result[2])
+      end
+    )
+  end)
+
   describe('dot repeat edge cases', function()
     it('should handle repeat after empty selection', function()
       setup_buffer('zebra apple banana')

--- a/tests/operator_spec.lua
+++ b/tests/operator_spec.lua
@@ -927,4 +927,78 @@ describe('operator functionality', function()
       assert.are.equal('prefix zebra suffix', result[3])
     end)
   end)
+
+  describe('non-modifiable buffer (main-e3u)', function()
+    local notify_calls
+    local original_notify
+
+    before_each(function()
+      notify_calls = {}
+      original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notify_calls, { msg = msg, level = level })
+      end
+    end)
+
+    -- selene: allow(undefined_variable)
+    after_each(function()
+      vim.notify = original_notify
+      vim.bo.modifiable = true
+    end)
+
+    it('should notify and leave buffer unchanged when nomodifiable', function()
+      setup_buffer('zebra apple banana')
+      vim.bo.modifiable = false
+
+      set_operator_marks(1, 1, 1, 18)
+
+      local ok = pcall(operator.sort_operator, 'char', false)
+
+      assert.is_true(ok)
+
+      vim.bo.modifiable = true
+      local result = get_buffer_content()
+      assert.are.equal('zebra apple banana', result[1])
+
+      assert.is_true(#notify_calls >= 1)
+      local found_warn = false
+      for _, call in ipairs(notify_calls) do
+        if
+          call.level == vim.log.levels.WARN
+          and string.find(call.msg, 'modifiable', 1, true)
+        then
+          found_warn = true
+          break
+        end
+      end
+      assert.is_true(found_warn)
+    end)
+
+    it('should notify on visual mode sort when nomodifiable', function()
+      setup_buffer('zebra apple banana')
+      vim.bo.modifiable = false
+
+      set_visual_marks(1, 1, 1, 18)
+
+      local ok = pcall(operator.sort_operator, 'char', true)
+
+      assert.is_true(ok)
+
+      vim.bo.modifiable = true
+      local result = get_buffer_content()
+      assert.are.equal('zebra apple banana', result[1])
+
+      local found_warn = false
+      for _, call in ipairs(notify_calls) do
+        if
+          call.level == vim.log.levels.WARN
+          and string.find(call.msg, 'modifiable', 1, true)
+        then
+          found_warn = true
+          break
+        end
+      end
+      assert.is_true(found_warn)
+    end)
+  end)
 end)

--- a/tests/operator_spec.lua
+++ b/tests/operator_spec.lua
@@ -1001,4 +1001,39 @@ describe('operator functionality', function()
       assert.is_true(found_warn)
     end)
   end)
+
+  describe('motion promotion heuristic (main-qbw)', function()
+    it(
+      'should preserve partial end on line 3 for char motion across 3+ lines',
+      function()
+        setup_buffer({ 'zebra', 'apple', 'banana TAIL' })
+
+        -- Char motion from line 1 col 1 to line 3 col 6 (partial — only 'banana').
+        set_operator_marks(1, 1, 3, 6)
+
+        operator.sort_operator('char', false)
+
+        local result = get_buffer_content()
+        -- Line 3 must retain its ' TAIL' suffix; without the fix, the
+        -- selection was promoted to line mode and line 3 was sorted as a
+        -- whole, replacing it with another line's content.
+        assert.are.equal('banana TAIL', result[3])
+      end
+    )
+
+    it(
+      'should still treat full-line-to-full-line char motion as line mode',
+      function()
+        setup_buffer({ 'zebra', 'apple', 'banana' })
+
+        -- Char motion covering all three full lines.
+        set_operator_marks(1, 1, 3, 6)
+
+        operator.sort_operator('char', false)
+
+        local result = get_buffer_content()
+        assert.are.same({ 'apple', 'banana', 'zebra' }, result)
+      end
+    )
+  end)
 end)

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -424,8 +424,10 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      -- The actual result from implementation (whitespace preserved during sort).
-      assert.are.equal('apple\r,banana\t,cherry\n', result)
+      -- Per the whitespace policy: when order changes, inter-item trailing
+      -- whitespace is normalized away. Only the input's outer trailing is
+      -- preserved — here the original last item (banana) had trailing '\t'.
+      assert.are.equal('apple,banana,cherry\t', result)
     end)
 
     it('should handle whitespace-only segments', function()
@@ -581,6 +583,49 @@ describe('sort', function()
 
         local result = sort.delimiter_sort(text, options)
         assert.are.equal('b, d,   e, f, l', result)
+      end
+    )
+
+    it(
+      'should apply uniform whitespace policy regardless of item position (main-jla)',
+      function()
+        local options = {
+          delimiter = ',',
+          ignore_case = false,
+          numerical = nil,
+          reverse = false,
+          unique = false,
+        }
+
+        -- Input with inconsistent internal spacing collapses to a uniform gap;
+        -- no outer whitespace is introduced when the input had none.
+        assert.are.equal('a, b, c', sort.delimiter_sort('c , a , b', options))
+
+        -- Input's outer whitespace is preserved; internal gap is uniform and
+        -- independent of which item ends up at each boundary.
+        assert.are.equal(' a, b, c ', sort.delimiter_sort(' c,b,a ', options))
+      end
+    )
+
+    it(
+      'should treat first, middle, and last items identically (main-jla)',
+      function()
+        local options = {
+          delimiter = ',',
+          ignore_case = false,
+          numerical = nil,
+          reverse = false,
+          unique = false,
+        }
+
+        -- Every item in the input has shape ` x ` (single space on both
+        -- sides) and outer whitespace is a single space on each end. Under
+        -- the uniform policy, every inter-item gap is the same and the outer
+        -- whitespace on the output matches the input.
+        assert.are.equal(
+          ' a, b, c ',
+          sort.delimiter_sort(' c , a , b ', options)
+        )
       end
     )
   end)

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -55,7 +55,35 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      assert.are.equal(',,,apple,banana,cherry,', result)
+      assert.are.equal(',apple,banana,cherry,', result)
+    end)
+
+    it('should handle leading delimiter without trailing', function()
+      local text = ',c,a,b'
+      local options = {
+        delimiter = ',',
+        ignore_case = false,
+        numerical = nil,
+        reverse = false,
+        unique = false,
+      }
+
+      local result = sort.delimiter_sort(text, options)
+      assert.are.equal(',a,b,c', result)
+    end)
+
+    it('should handle leading and trailing delimiter short case', function()
+      local text = ',c,a,b,'
+      local options = {
+        delimiter = ',',
+        ignore_case = false,
+        numerical = nil,
+        reverse = false,
+        unique = false,
+      }
+
+      local result = sort.delimiter_sort(text, options)
+      assert.are.equal(',a,b,c,', result)
     end)
 
     it(
@@ -214,7 +242,7 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      assert.are.equal(',,,,,', result)
+      assert.are.equal(',,,', result)
     end)
 
     -- Delimiter translation tests.

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -1446,7 +1446,7 @@ describe('sort', function()
       assert.are.equal(' -90 , -10 , 5 ', result)
     end)
 
-    it('should skip empty segments in detection', function()
+    it('should sort empty segments after numbers', function()
       local text = '-10,,-90,5'
       local options = {
         delimiter = nil,
@@ -1458,7 +1458,7 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      assert.are.equal('-90,-10,,5', result)
+      assert.are.equal('-90,-10,5,', result)
     end)
 
     it('should reverse mathematical sort correctly', function()
@@ -1551,7 +1551,7 @@ describe('sort', function()
       assert.are.equal('-1,-10,-90', result)
     end)
 
-    it('should handle empty segments as 0 in math sort', function()
+    it('should sort empty segments after numbers in math sort', function()
       local text = '-10,,-5,10'
       local options = {
         delimiter = nil,
@@ -1563,7 +1563,7 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      assert.are.equal('-10,-5,,10', result)
+      assert.are.equal('-10,-5,10,', result)
     end)
   end)
 
@@ -1664,7 +1664,7 @@ describe('sort', function()
       assert.are.equal('-1\n-10\n-90', result)
     end)
 
-    it('should handle empty lines as 0 in math sort', function()
+    it('should sort empty lines after numbers in math sort', function()
       local text = '-10\n\n-5\n10'
       local options = {
         delimiter = nil,
@@ -1676,7 +1676,7 @@ describe('sort', function()
       }
 
       local result = sort.line_sort_text(text, options)
-      assert.are.equal('-10\n-5\n\n10', result)
+      assert.are.equal('-10\n-5\n10\n', result)
     end)
   end)
 

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -758,6 +758,21 @@ describe('sort', function()
   end)
 
   describe('natural sorting', function()
+    it('should sort negative numbers in mixed list numerically', function()
+      local text = '-5,-10,abc'
+      local options = {
+        delimiter = ',',
+        ignore_case = false,
+        numerical = nil,
+        reverse = false,
+        unique = false,
+        natural = true,
+      }
+
+      local result = sort.delimiter_sort(text, options)
+      assert.are.equal('-10,-5,abc', result)
+    end)
+
     -- Basic natural sorting tests
     it('should sort alphanumeric strings naturally', function()
       local text = 'item10,item2,item1,item20'
@@ -1457,7 +1472,7 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      assert.are.equal('-10,-90,item-10,item-12', result)
+      assert.are.equal('-90,-10,item-10,item-12', result)
     end)
 
     it('should preserve identifier sorting in mixed lists', function()
@@ -1584,7 +1599,7 @@ describe('sort', function()
         }
 
         local result = sort.line_sort_text(text, options)
-        assert.are.equal('-10\n-90\nitem-2\nitem-10', result)
+        assert.are.equal('-90\n-10\nitem-2\nitem-10', result)
       end
     )
 

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -545,8 +545,9 @@ describe('sort', function()
       }
 
       local result = sort.delimiter_sort(text, options)
-      -- With numerical sorting, these are sorted by numeric value first, then alphabetically.
-      assert.are.equal('5b,10A,20A', result)
+      -- Items are not pure numbers (alpha suffix); parse_number returns nil,
+      -- so comparison falls back to case-insensitive string sort.
+      assert.are.equal('10a,20A,5B', result)
     end)
 
     it(

--- a/tests/sort_spec.lua
+++ b/tests/sort_spec.lua
@@ -245,6 +245,43 @@ describe('sort', function()
       assert.are.equal(',,,', result)
     end)
 
+    -- Magic Lua pattern chars as delimiters (must be treated literally).
+    it('should treat magic pattern chars as literal delimiters', function()
+      local cases = {
+        { input = 'c(a(b', delim = '(', expected = 'a(b(c' },
+        { input = 'c)a)b', delim = ')', expected = 'a)b)c' },
+        { input = 'c%a%b', delim = '%', expected = 'a%b%c' },
+        { input = 'c.a.b', delim = '.', expected = 'a.b.c' },
+        { input = 'c+a+b', delim = '+', expected = 'a+b+c' },
+        { input = 'c*a*b', delim = '*', expected = 'a*b*c' },
+        { input = 'c?a?b', delim = '?', expected = 'a?b?c' },
+        { input = 'c^a^b', delim = '^', expected = 'a^b^c' },
+        { input = 'c$a$b', delim = '$', expected = 'a$b$c' },
+        { input = 'c-a-b', delim = '-', expected = 'a-b-c' },
+      }
+      for _, case in ipairs(cases) do
+        local result = sort.delimiter_sort(case.input, {
+          delimiter = case.delim,
+          ignore_case = false,
+          numerical = nil,
+          reverse = false,
+          unique = false,
+        })
+        assert.are.equal(case.expected, result)
+      end
+    end)
+
+    it('should preserve leading/trailing dot delimiter', function()
+      local result = sort.delimiter_sort('.c.a.b.', {
+        delimiter = '.',
+        ignore_case = false,
+        numerical = nil,
+        reverse = false,
+        unique = false,
+      })
+      assert.are.equal('.a.b.c.', result)
+    end)
+
     -- Delimiter translation tests.
     it('should handle tab delimiter translation', function()
       local text = 'cherry\tapple\tbanana'

--- a/tests/textobjects_spec.lua
+++ b/tests/textobjects_spec.lua
@@ -60,6 +60,38 @@ describe('textobjects', function()
         assert.are.equal('aa,', selected)
       end
     )
+
+    it(
+      'skips empty leading segment when cursor is on the leading delimiter',
+      function()
+        setup_buffer(',a,b')
+        place_cursor(0)
+
+        local region = textobjects._find_sortable_region(false)
+
+        assert.is_not_nil(region)
+        assert.is_true(region.to.column >= region.from.column)
+        local selected =
+          string.sub(',a,b', region.from.column, region.to.column)
+        assert.are.equal('a', selected)
+      end
+    )
+
+    it(
+      'skips empty trailing segment when cursor is past the trailing delimiter',
+      function()
+        setup_buffer('a,b,')
+        place_cursor(4)
+
+        local region = textobjects._find_sortable_region(false)
+
+        assert.is_not_nil(region)
+        assert.is_true(region.to.column >= region.from.column)
+        local selected =
+          string.sub('a,b,', region.from.column, region.to.column)
+        assert.are.equal('b', selected)
+      end
+    )
   end)
 
   describe('_apply_selection', function()

--- a/tests/textobjects_spec.lua
+++ b/tests/textobjects_spec.lua
@@ -61,4 +61,44 @@ describe('textobjects', function()
       end
     )
   end)
+
+  describe('_apply_selection', function()
+    before_each(function()
+      pcall(vim.api.nvim_buf_del_mark, 0, '<')
+      pcall(vim.api.nvim_buf_del_mark, 0, '>')
+    end)
+
+    it('sets < and > marks when invoked in visual mode', function()
+      setup_buffer('aa,bb,cc')
+      place_cursor(0)
+
+      local selection = {
+        from = { row = 1, column = 1 },
+        to = { row = 1, column = 2 },
+      }
+      textobjects._apply_selection(selection, 'v')
+
+      local lt = vim.api.nvim_buf_get_mark(0, '<')
+      local gt = vim.api.nvim_buf_get_mark(0, '>')
+      assert.are.equal(1, lt[1])
+      assert.are.equal(0, lt[2])
+      assert.are.equal(1, gt[1])
+      assert.are.equal(1, gt[2])
+    end)
+
+    it('moves cursor to selection end in operator-pending mode', function()
+      setup_buffer('aa,bb,cc')
+      place_cursor(0)
+
+      local selection = {
+        from = { row = 1, column = 4 },
+        to = { row = 1, column = 5 },
+      }
+      textobjects._apply_selection(selection, 'no')
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.are.equal(1, cursor[1])
+      assert.are.equal(4, cursor[2])
+    end)
+  end)
 end)

--- a/tests/textobjects_spec.lua
+++ b/tests/textobjects_spec.lua
@@ -1,0 +1,64 @@
+describe('textobjects', function()
+  local textobjects = require('sort.textobjects')
+
+  local function setup_buffer(content)
+    vim.cmd('enew')
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { content })
+  end
+
+  local function place_cursor(col_zero_based)
+    vim.api.nvim_win_set_cursor(0, { 1, col_zero_based })
+  end
+
+  describe('_find_sortable_region', function()
+    it('selects the segment the cursor is inside', function()
+      setup_buffer('aa,bb,cc')
+      place_cursor(3)
+
+      local region = textobjects._find_sortable_region(false)
+
+      assert.is_not_nil(region)
+      assert.are.equal(4, region.from.column)
+      assert.are.equal(5, region.to.column)
+    end)
+
+    it('snaps to preceding segment when cursor is on a delimiter', function()
+      setup_buffer('aa,bb,cc')
+      place_cursor(2)
+
+      local region = textobjects._find_sortable_region(false)
+
+      assert.is_not_nil(region)
+      local selected =
+        string.sub('aa,bb,cc', region.from.column, region.to.column)
+      assert.are.equal('aa', selected)
+    end)
+
+    it('snaps to last segment when cursor is past the line', function()
+      setup_buffer('aa,bb,cc')
+      place_cursor(10)
+
+      local region = textobjects._find_sortable_region(false)
+
+      assert.is_not_nil(region)
+      local selected =
+        string.sub('aa,bb,cc', region.from.column, region.to.column)
+      assert.are.equal('cc', selected)
+    end)
+
+    it(
+      'snaps around preceding segment when cursor is on delimiter with include_delimiters',
+      function()
+        setup_buffer('aa,bb,cc')
+        place_cursor(2)
+
+        local region = textobjects._find_sortable_region(true)
+
+        assert.is_not_nil(region)
+        local selected =
+          string.sub('aa,bb,cc', region.from.column, region.to.column)
+        assert.are.equal('aa,', selected)
+      end
+    )
+  end)
+end)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -861,16 +861,24 @@ describe('utils', function()
       assert.is_true(utils.math_compare('abc', 'def'))
     end)
 
-    it('should treat empty string as 0 when compared with positive', function()
-      assert.is_true(utils.math_compare('', '5'))
+    it('should sort empty strings after positive numbers', function()
+      assert.is_false(utils.math_compare('', '5'))
+      assert.is_true(utils.math_compare('5', ''))
     end)
 
-    it('should treat empty string as 0 when compared with negative', function()
+    it('should sort empty strings after negative numbers', function()
       assert.is_false(utils.math_compare('', '-5'))
+      assert.is_true(utils.math_compare('-5', ''))
     end)
 
     it('should return false when comparing two empty strings', function()
       assert.is_false(utils.math_compare('', ''))
+    end)
+
+    it('should order positives, negatives, and empties consistently', function()
+      local items = { '', '5', '-3', '', '0' }
+      table.sort(items, utils.math_compare)
+      assert.are.same({ '-3', '0', '5', '', '' }, items)
     end)
 
     it('should fall back to string comparison when one is invalid', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -415,6 +415,12 @@ describe('utils', function()
       assert.are.equal('hello', result)
     end)
 
+    it('should strip NEL (U+0085)', function()
+      local result =
+        utils.trim_leading_and_trailing_whitespace('\194\133hello\194\133')
+      assert.are.equal('hello', result)
+    end)
+
     it('should strip mixed ASCII and Unicode whitespace', function()
       local result = utils.trim_leading_and_trailing_whitespace(
         ' \194\160\t hello \194\160 '

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -105,6 +105,25 @@ describe('utils', function()
       local result = utils.split_by_delimiter('a\tb\tc', '\t')
       assert.are.same({ 'a', 'b', 'c' }, result)
     end)
+
+    it(
+      'should split literally through quoted regions (main-8v6: quote-awareness is unsupported)',
+      function()
+        -- The plugin does not implement CSV/quote-aware splitting. Delimiters
+        -- inside quoted strings or brackets are treated as normal delimiters.
+        -- This test locks in the literal behavior so any future change to add
+        -- quote awareness is a conscious, documented decision rather than an
+        -- accidental regression. See README "Limitations".
+        assert.are.same(
+          { '"a', 'b"', 'c' },
+          utils.split_by_delimiter('"a,b",c', ',')
+        )
+        assert.are.same(
+          { '(a', 'b)', 'c' },
+          utils.split_by_delimiter('(a,b),c', ',')
+        )
+      end
+    )
   end)
 
   describe('parse_arguments', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -789,8 +789,12 @@ describe('utils', function()
       assert.is_false(utils.is_pure_number('.'))
     end)
 
-    it('should return false for leading decimal without zero', function()
-      assert.is_false(utils.is_pure_number('.5'))
+    it('should return true for leading decimal without zero', function()
+      assert.is_true(utils.is_pure_number('.5'))
+    end)
+
+    it('should return true for negative leading decimal', function()
+      assert.is_true(utils.is_pure_number('-.5'))
     end)
 
     it('should return true for trailing decimal', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -219,6 +219,46 @@ describe('utils', function()
       local result = utils.parse_arguments('', 'iuz')
       assert.is_nil(result.delimiter)
     end)
+
+    it(
+      'should not treat "s" as delimiter when combined with flag letters',
+      function()
+        local result = utils.parse_arguments('', 'us')
+        assert.are.equal(true, result.unique)
+        assert.is_nil(result.delimiter)
+      end
+    )
+
+    it(
+      'should not treat "t" as delimiter when combined with flag letters',
+      function()
+        local result = utils.parse_arguments('', 'ut')
+        assert.are.equal(true, result.unique)
+        assert.is_nil(result.delimiter)
+      end
+    )
+
+    it('should still allow punctuation delimiter with flag letters', function()
+      local result = utils.parse_arguments('', 'u,')
+      assert.are.equal(true, result.unique)
+      assert.are.equal(',', result.delimiter)
+    end)
+
+    it('should not misparse completely unknown flag characters', function()
+      local notify_calls = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        notify_calls[#notify_calls + 1] = { msg = msg, level = level }
+      end
+
+      local result = utils.parse_arguments('', 'xyz')
+      vim.notify = original_notify
+
+      assert.are.equal(true, result.natural)
+      assert.are.equal(16, result.numerical)
+      assert.is_true(#notify_calls >= 1)
+      assert.is_true(string.find(notify_calls[1].msg, 'y', 1, true) ~= nil)
+    end)
   end)
 
   describe('parse_number', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -31,6 +31,11 @@ describe('utils', function()
       local result = utils.get_leading_whitespace('')
       assert.are.equal('', result)
     end)
+
+    it('should match NBSP as leading whitespace', function()
+      local result = utils.get_leading_whitespace('\194\160hello')
+      assert.are.equal('\194\160', result)
+    end)
   end)
 
   describe('get_trailing_whitespace', function()
@@ -62,6 +67,11 @@ describe('utils', function()
     it('should return empty string for empty input', function()
       local result = utils.get_trailing_whitespace('')
       assert.are.equal('', result)
+    end)
+
+    it('should match NBSP as trailing whitespace', function()
+      local result = utils.get_trailing_whitespace('hello\194\160')
+      assert.are.equal('\194\160', result)
     end)
   end)
 
@@ -343,6 +353,33 @@ describe('utils', function()
     it('should return empty for empty input', function()
       local result = utils.trim_leading_and_trailing_whitespace('')
       assert.are.equal('', result)
+    end)
+
+    it('should strip NBSP (U+00A0)', function()
+      local result =
+        utils.trim_leading_and_trailing_whitespace('\194\160hello\194\160')
+      assert.are.equal('hello', result)
+    end)
+
+    it('should strip ideographic space (U+3000)', function()
+      local result = utils.trim_leading_and_trailing_whitespace(
+        '\227\128\128hello\227\128\128'
+      )
+      assert.are.equal('hello', result)
+    end)
+
+    it('should strip line separator (U+2028)', function()
+      local result = utils.trim_leading_and_trailing_whitespace(
+        '\226\128\168hello\226\128\168'
+      )
+      assert.are.equal('hello', result)
+    end)
+
+    it('should strip mixed ASCII and Unicode whitespace', function()
+      local result = utils.trim_leading_and_trailing_whitespace(
+        ' \194\160\t hello \194\160 '
+      )
+      assert.are.equal('hello', result)
     end)
   end)
 

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -457,13 +457,33 @@ describe('utils', function()
       end
     end)
 
-    it('should handle punctuation at start', function()
+    it('should parse leading minus with digits as signed number', function()
       local result = utils.parse_natural_segments('-123')
-      assert.are.equal(2, #result)
-      assert.are.equal('-', result[1].text)
-      assert.are.equal(true, result[1].is_punctuation)
-      assert.are.equal('123', result[2].text)
-      assert.are.equal(true, result[2].is_number)
+      assert.are.equal(1, #result)
+      assert.are.equal('-123', result[1].text)
+      assert.are.equal(true, result[1].is_number)
+      assert.are.equal(false, result[1].is_punctuation)
+    end)
+
+    it(
+      'should keep leading minus as punctuation when not followed by digit',
+      function()
+        local result = utils.parse_natural_segments('-abc')
+        assert.are.equal(2, #result)
+        assert.are.equal('-', result[1].text)
+        assert.are.equal(true, result[1].is_punctuation)
+        assert.are.equal('abc', result[2].text)
+      end
+    )
+
+    it('should treat mid-string dash as separator, not sign', function()
+      local result = utils.parse_natural_segments('a-5')
+      assert.are.equal(3, #result)
+      assert.are.equal('a', result[1].text)
+      assert.are.equal('-', result[2].text)
+      assert.are.equal(true, result[2].is_punctuation)
+      assert.are.equal('5', result[3].text)
+      assert.are.equal(true, result[3].is_number)
     end)
 
     it('should treat non-ASCII bytes as punctuation', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -238,6 +238,26 @@ describe('utils', function()
       end
     )
 
+    it(
+      'should warn with a targeted message for s/t combined with flags',
+      function()
+        local notify_calls = {}
+        local original_notify = vim.notify
+        vim.notify = function(msg, level)
+          notify_calls[#notify_calls + 1] = { msg = msg, level = level }
+        end
+
+        utils.parse_arguments('', 'us')
+        vim.notify = original_notify
+
+        assert.is_true(#notify_calls >= 1)
+        assert.is_true(
+          string.find(notify_calls[1].msg, 'standalone', 1, true) ~= nil
+        )
+        assert.is_true(string.find(notify_calls[1].msg, "'s'", 1, true) ~= nil)
+      end
+    )
+
     it('should still allow punctuation delimiter with flag letters', function()
       local result = utils.parse_arguments('', 'u,')
       assert.are.equal(true, result.unique)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -238,14 +238,37 @@ describe('utils', function()
       assert.are.equal(3.14, result)
     end)
 
-    it('should parse partial valid binary from mixed input', function()
-      local result = utils.parse_number('123', 2)
-      assert.are.equal(1, result)
-    end)
+    it(
+      'should return nil when mixed input is not a pure binary number',
+      function()
+        local result = utils.parse_number('123', 2)
+        assert.is_nil(result)
+      end
+    )
 
     it('should return nil for empty string', function()
       local result = utils.parse_number('', 10)
       assert.is_nil(result)
+    end)
+
+    it('should return nil for embedded digits at start in binary', function()
+      assert.is_nil(utils.parse_number('abc01', 2))
+    end)
+
+    it('should return nil for trailing non-digits in decimal', function()
+      assert.is_nil(utils.parse_number('5xyz', 10))
+    end)
+
+    it('should return nil for leading non-digits in decimal', function()
+      assert.is_nil(utils.parse_number('foo-5bar', 10))
+    end)
+
+    it('should return nil for embedded 0x prefix in hex', function()
+      assert.is_nil(utils.parse_number('hello0x2A', 16))
+    end)
+
+    it('should return nil for mixed content in octal', function()
+      assert.is_nil(utils.parse_number('77abc', 8))
     end)
   end)
 


### PR DESCRIPTION
#### Motivation

Audit and fix a batch of bugs surfaced during a post-2.4.0 review — correctness issues in delimiter sorting, whitespace handling, natural sort, flag parsing, and operator semantics. Landed as a single branch so the set ships under one patch release (2.4.1).

#### Changes

**Sort correctness (`lua/sort/sort.lua`, `lua/sort/utils.lua`)**

- Uniform whitespace policy for delimiter sort: outer whitespace of the input is preserved; interior gaps collapse to the dominant pattern regardless of which item lands at each boundary.
- Drop structural empty segments at both boundaries, eliminating duplicate delimiters when inputs start with the delimiter.
- Escape magic Lua pattern chars (`vim.pesc`) when detecting leading/trailing delimiter, so `(`, `)`, `.`, `%`, `+`, `*`, `?`, `^`, `$`, `-` work as literal delimiters.
- `parse_number` patterns anchored (`^...$`) so `5xyz` no longer parses as `5`.
- `is_pure_number` accepts `.5` / `-.5` via a second dot-first mantissa pattern.
- Natural-sort parser treats a leading `-` before digits as a sign, restoring numeric order for mixed lists like `-10, -5, abc`.
- `math_compare` orders empty strings after numbers instead of coercing to zero.
- Whitespace trimming honors Unicode White_Space (NBSP, ideographic space, line/paragraph separators, em/en quads, etc.), not only ASCII `%s`.

**Operator semantics (`lua/sort/operator.lua`, `lua/sort/mappings.lua`)**

- Snapshot config at keymap press; dot-repeat reuses that snapshot instead of reading live config, matching vim-repeat semantics.
- Guard against non-modifiable buffers — warn and abort instead of erroring.
- Promote multi-line char motions to line motions only when both boundaries are line-shaped, preserving partial 3+ line selections.

**Text objects (`lua/sort/textobjects.lua`)**

- Snap deterministically to a segment when cursor sits on a delimiter or past the last segment.
- Preserve the visual selection when `is`/`as` is invoked in visual mode (use `<`/`>` + `gv` instead of `normal! v`).

**Config (`lua/sort/config.lua`)**

- Validate override types (delimiters list-of-strings; keymap/mappings strings; natural_sort/ignore_case/unique booleans; whitespace.alignment_threshold non-negative number) — warn and drop invalid keys instead of silently accepting.
- Validate nested `mappings` structure (operator, textobject.{inner,around}, motion.{next_delimiter,prev_delimiter}), honoring \`false\` sentinel.
- Deep-copy overrides before validation so callers' tables aren't mutated.
- Layered \`setup()\` calls preserve prior keys (base changed from \`defaults\` to \`user_config\`).

**Docs and changelog**

- README documents that delimiter splitting is literal — quoted strings and bracket-protected regions are not honored.
- CHANGELOG entry for 2.4.1 (Keep a Changelog format, patch-appropriate \`Fixed\`-only section for semver validation).

**Tests**

- New \`tests/textobjects_spec.lua\` covering segment snapping and mode-aware selection.
- New config validation cases (mappings structure, non-mutation invariant).
- New operator cases for nomodifiable buffers, motion promotion heuristic, and dot-repeat snapshot semantics.

#### Test plan

- [x] \`./scripts/test\` — full suite (411 cases passing, covers every fix above including nomodifiable-buffer and dot-repeat snapshot behaviors)
- [x] \`./scripts/release --dry-run 2.4.1\` — pre-flight checks pass (expected warning on non-main branch; real release runs from main post-merge)